### PR TITLE
Add Auto Deployments with CloudRun + GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+.git
+Dockerfile
+app.yaml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,78 @@
+#
+# Copyright 2013-2020 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Deploy JHipster Online
+on:
+  release:
+    types: [published]
+jobs:
+  pipeline:
+    name: jhipster-online deployment
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      # Checkout with all submodules
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+
+      # Substitutes the variables/secrets
+      - uses: microsoft/variable-substitution@v1
+        with:
+          files: '${{ github.workspace }}/app.yaml'
+        env:
+          env_variables.DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
+          env_variables.INSTANCE_CONNECTION_NAME: ${{ secrets.INSTANCE_CONNECTION_NAME }}
+          env_variables.GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          env_variables.GCP_REGION: ${{ secrets.GCP_REGION }}
+          env_variables.SQL_INSTANCE_ID: ${{ secrets.SQL_INSTANCE_ID }}
+          env_variables.DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+          env_variables.DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          env_variables.MAIL_HOST: ${{ secrets.MAIL_HOST }}
+          env_variables.MAIL_PORT: ${{ secrets.MAIL_PORT }}
+          env_variables.MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+          env_variables.MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          env_variables.BASE64_SECRET: ${{ secrets.BASE64_SECRET }}
+          env_variables.CLIENT_ID_GITHUB: ${{ secrets.CLIENT_ID_GITHUB }}
+          env_variables.CLIENT_SECRET_GITHUB: ${{ secrets.CLIENT_SECRET_GITHUB }}
+          env_variables.JHIPSTER_BOT_OAUTH_TOKEN: ${{ secrets.JHIPSTER_BOT_OAUTH_TOKEN }}
+          env_variables.GITLAB_CLIENT_ID: ${{ secrets.GITLAB_CLIENT_ID }}
+          env_variables.GITLAB_CLIENT_SECRET: ${{ secrets.GITLAB_CLIENT_SECRET }}
+          env_variables.GITLAB_REDIRECT_URI: ${{ secrets.GITLAB_REDIRECT_URI }}
+
+      # Setup gcloud CLI
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      # Build and push docker image to GCR
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v1
+        with:
+          username: _json_key
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: eu.gcr.io
+          repository: jhipster-online/appengine
+          tag_with_sha: true
+
+      # Deploy to App Engine Flexible
+      - name: Deploy
+        run: VERSION_TAG=${GITHUB_REF:10} && gcloud app deploy --image-url eu.gcr.io/jhipster-online/appengine:sha-${GITHUB_SHA::7} --version ${VERSION_TAG//./-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
     rm -Rf target node_modules && \
     chmod +x /code/mvnw && \
     sleep 1 && \
-    ./mvnw package -Pprod -DskipTests && \
+    ./mvnw package -Pgcp -DskipTests && \
     mv /code/target/*.war / && \
     apt-get clean && \
     rm -Rf /code/ /root/.m2 /root/.cache /tmp/* /var/lib/apt/lists/* /var/tmp/*  && \

--- a/README.md
+++ b/README.md
@@ -186,11 +186,14 @@ Then run:
 docker-compose -f src/main/docker/app.yml up -d
 ```
 
-## Building for GCP environment (include sql proxy)
+## Deployment to Google App Engine (GAE) Flexible Environment
 
-```
-./mvnw clean package -Pgcp
-```
+- The project can be deployed to [GAE flexible environment](https://cloud.google.com/appengine/docs/flexible/) by simply [creating a tagged release](https://github.com/jhipster/jhipster-online/releases).
+
+- Creating a new release triggers the [deploy.yml GitHub Actions workflow](https://github.com/jhipster/jhipster-online/blob/master/.github/workflows/deploy.yml).
+
+- The above workflow includes a Docker build and pushes the image to [Google Container Registry](https://cloud.google.com/container-registry/). [Cloud Monitoring](https://cloud.google.com/monitoring) and [Cloud Logging](https://cloud.google.com/logging) are used for
+  obtaining application logs and monitoring.
 
 ## Help and contribution to the project
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,29 @@
+runtime: custom
+env: flex
+resources:
+    cpu: 1
+    memory_gb: 3.0
+    disk_size_gb: 10
+manual_scaling:
+    instances: 1
+env_variables:
+    DATABASE_NAME:
+    INSTANCE_CONNECTION_NAME:
+    GCP_PROJECT_ID:
+    GCP_REGION:
+    SQL_INSTANCE_ID:
+    DATABASE_USERNAME:
+    DATABASE_PASSWORD:
+    MAIL_HOST:
+    MAIL_PORT:
+    MAIL_USERNAME:
+    MAIL_PASSWORD:
+    BASE64_SECRET:
+    CLIENT_ID_GITHUB:
+    CLIENT_SECRET_GITHUB:
+    JHIPSTER_BOT_OAUTH_TOKEN:
+    GITLAB_CLIENT_ID:
+    GITLAB_CLIENT_SECRET:
+    GITLAB_REDIRECT_URI:
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,6 @@
         <junit.utReportFolder>${project.testresult.directory}/test</junit.utReportFolder>
         <junit.itReportFolder>${project.testresult.directory}/integrationTest</junit.itReportFolder>
         <!-- jhipster-needle-maven-property -->
-        <mysql-socket-factory.version>1.0.16</mysql-socket-factory.version>
     </properties>
 
     <dependencyManagement>
@@ -95,6 +94,13 @@
                 <groupId>io.github.jhipster</groupId>
                 <artifactId>jhipster-dependencies</artifactId>
                 <version>${jhipster-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>1.2.2.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -1090,9 +1096,8 @@
                     <artifactId>spring-boot-starter-undertow</artifactId>
                 </dependency>
                 <dependency>
-                    <groupId>com.google.cloud.sql</groupId>
-                    <artifactId>mysql-socket-factory</artifactId>
-                    <version>${mysql-socket-factory.version}</version>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-gcp-starter-sql-mysql</artifactId>
                 </dependency>
             </dependencies>
             <build>
@@ -1176,7 +1181,7 @@
             </build>
             <properties>
                 <!-- default Spring profiles -->
-                <spring.profiles.active>prod${profile.swagger}${profile.no-liquibase}</spring.profiles.active>
+                <spring.profiles.active>prod,gcp${profile.swagger}${profile.no-liquibase}</spring.profiles.active>
             </properties>
         </profile>
         <profile>

--- a/src/main/resources/config/application-gcp.yml
+++ b/src/main/resources/config/application-gcp.yml
@@ -1,0 +1,54 @@
+# ===================================================================
+# Spring Boot configuration for the "gcp" profile.
+#
+# This configuration overrides the application.yml file.
+#
+# More information on profiles: https://www.jhipster.tech/profiles/
+# More information on configuration properties: https://www.jhipster.tech/common-application-properties/
+# ===================================================================
+
+# ===================================================================
+# Standard Spring Boot properties.
+# Full reference is available at:
+# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# ===================================================================
+
+spring:
+  cloud:
+    gcp:
+      sql:
+        enabled: true
+        database-name: ${DATABASE_NAME}
+        instance-connection-name: ${INSTANCE_CONNECTION_NAME}
+  datasource:
+    hikari:
+      data-source-properties:
+        socketFactory: com.google.cloud.sql.mysql.SocketFactory
+        cloudSqlInstance: ${GCP_PROJECT_ID}:${GCP_REGION}:${SQL_INSTANCE_ID}
+      jdbcUrl: jdbc:mysql://google/${DATABASE_NAME}
+      username: ${DATABASE_USERNAME}
+      password: ${DATABASE_PASSWORD}
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+server:
+  port: ${PORT}
+jhipster:
+  mail: # specific JHipster mail property, for standard properties see MailProperties
+    enabled: true
+    base-url: https://start.jhipster.tech
+  security:
+    authentication:
+      jwt:
+        base64-secret: ${BASE64_SECRET}
+application:
+  github:
+    client-id: ${CLIENT_ID_GITHUB}
+    client-secret: ${CLIENT_SECRET_GITHUB}
+    jhipster-bot-oauth-token: ${JHIPSTER_BOT_OAUTH_TOKEN}
+  gitlab:
+    client-id: ${GITLAB_CLIENT_ID}
+    client-secret: ${GITLAB_CLIENT_SECRET}
+    redirect-uri: ${GITLAB_REDIRECT_URI}

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -141,14 +141,3 @@ application:
   jhipster-cmd:
     cmd: jhipster
     timeout: 120
-#    github:
-#        host: https://github.com
-#        client-id: XXX
-#        client-secret: XXX
-#        jhipster-bot-oauth-token: XXX
-#    gitlab:
-#        host: https://gitlab.com
-#        client-id: XXX
-#        client-secret: XXX
-#        redirect-uri: XXX
-#        jhipster-bot-oauth-token: XXX


### PR DESCRIPTION
This basically takes away most of the developer effort in deploying jhipster-online, and automates the deployment using CloudRun + GitHub Actions.

Fixes https://github.com/jhipster/jhipster-online/issues/172