### PR TITLE
Add es2015 Bundling Back into webpack.common.js

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -10,7 +10,7 @@ module.exports = options => ({
   resolve: {
     extensions: ['.ts', '.js'],
     modules: ['node_modules'],
-    mainFields: ['browser', 'module', 'main'],
+    mainFields: ['es2015', 'browser', 'module', 'main'],
     alias: utils.mapTypescriptAliasToWebpackAlias()
   },
   stats: {


### PR DESCRIPTION
This adds es2015 bundling back into the webpack configuration. We removed it previously due to Firefox bug effecting Firefox versions < 77

Related to https://github.com/jhipster/generator-jhipster/issues/11566 and https://github.com/jhipster/generator-jhipster/pull/11619 