### PR TITLE
Add dependabot.yml file for automatic version upgrades [ci skip]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This adds dependabot.yml file to leverage native support for dependabot through GitHub.

Related to https://github.com/jhipster/generator-jhipster/issues/11914