### PR TITLE
Add GitHub Actions and CircleCI for Continuous Integration

### DIFF
--- a/src/main/java/io/github/jhipster/online/service/enums/CiCdTool.java
+++ b/src/main/java/io/github/jhipster/online/service/enums/CiCdTool.java
@@ -12,7 +12,9 @@ public enum CiCdTool {
     TRAVIS,
     JENKINS,
     GITLAB,
-    AZURE;
+    AZURE,
+    CIRCLE,
+    GITHUB;
 
     public static Optional<CiCdTool> getByName(String name) {
         return Stream

--- a/src/main/webapp/app/home/ci-cd/ci-cd.component.html
+++ b/src/main/webapp/app/home/ci-cd/ci-cd.component.html
@@ -45,6 +45,20 @@
                         <li>Create a new pipeline using your project</li>
                     </ul>
                 </div>
+                <div class="col-md-6">
+                    <h3><a href="https://circleci.com/">CircleCI</a></h3>
+                    <ul>
+                        <li>A <code>circle.yml</code> will be added to your project.</li>
+                        <li>Create a CircleCI integration depending on your VCS; https://circleci.com/integrations/</li>
+                    </ul>
+                </div>
+                <div class="col-md-6">
+                    <h3><a href="https://github.com/features/actions">GitHub Actions</a></h3>
+                    <ul>
+                        <li>A <code>github-ci.yml</code> will be added to your project.</li>
+                        <li>Push the project to GitHub; the actions workflow will be configured on your GitHub repo.</li>
+                    </ul>
+                </div>
             </div>
         </div>
         <hr/>
@@ -61,6 +75,8 @@
                             <option value="jenkins">Jenkins</option>
                             <option value="gitlab">Gitlab</option>
                             <option value="azure">Azure Pipelines</option>
+                            <option value="circle">CircleCI</option>
+                            <option value="github">GitHub Actions</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
This adds the GitHub Actions and CircleCI to the list of continuous integration options.

Fixes https://github.com/jhipster/jhipster-online/issues/163