### PR TITLE
Add SonarCloud Analysis to CI

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -55,5 +55,19 @@ jobs:
       - name: Run frontend test
         run: yarn test
 
+      - name: Sonar analysis
+        if: github.repository == 'jhipster/jhipster-online' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/master')
+        run: |
+          ./mvnw -ntp --batch-mode initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
+          -Dsonar.host.url=https://sonarcloud.io \
+          -Dsonar.projectKey=jhipster_jhipster-online \
+          -Dsonar.organization=jhipster \
+          -Dsonar.pullrequest.key=$PULL_REQUEST_NUMBER \
+          -Dsonar.login=$SONAR_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+
       - name: Package application
         run: ./mvnw -ntp package -Pprod -DskipTests


### PR DESCRIPTION
This adds SonarCloud analysis to CI; the analysis should be triggered for PRs as well. 

Resolves https://github.com/jhipster/jhipster-online/issues/202