### PR TITLE
Add Non-blocking input.ready() call for BufferReader

### DIFF
--- a/src/main/java/io/github/jhipster/online/service/JHipsterService.java
+++ b/src/main/java/io/github/jhipster/online/service/JHipsterService.java
@@ -106,7 +106,7 @@ public class JHipsterService {
             input =
                 new BufferedReader
                     (new InputStreamReader(p.getInputStream()));
-            while ((line = input.readLine()) != null) {
+            while (input.ready() && (line = input.readLine()) != null) {
                 log.debug(line);
                 this.logsService.addLog(generationId, line);
             }


### PR DESCRIPTION
This adds a non-blocking input.ready() call for BufferReader.readline() as I've noticed that there's a possibility for this to block when reading the next line. 

Reference: https://stackoverflow.com/questions/15521352/bufferedreader-readline-blocks

Related to https://github.com/jhipster/jhipster-online/issues/184