### PR TITLE
Use a simplified database connection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,6 @@ jobs:
           files: '${{ github.workspace }}/app.yaml'
         env:
           env_variables.DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
-          env_variables.INSTANCE_CONNECTION_NAME: ${{ secrets.INSTANCE_CONNECTION_NAME }}
           env_variables.GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           env_variables.GCP_REGION: ${{ secrets.GCP_REGION }}
           env_variables.SQL_INSTANCE_ID: ${{ secrets.SQL_INSTANCE_ID }}

--- a/app.yaml
+++ b/app.yaml
@@ -8,7 +8,6 @@ manual_scaling:
     instances: 1
 env_variables:
     DATABASE_NAME:
-    INSTANCE_CONNECTION_NAME:
     GCP_PROJECT_ID:
     GCP_REGION:
     SQL_INSTANCE_ID:

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <junit.utReportFolder>${project.testresult.directory}/test</junit.utReportFolder>
         <junit.itReportFolder>${project.testresult.directory}/integrationTest</junit.itReportFolder>
         <!-- jhipster-needle-maven-property -->
+        <mysql-socket-factory.version>1.0.16</mysql-socket-factory.version>
     </properties>
 
     <dependencyManagement>
@@ -94,13 +95,6 @@
                 <groupId>io.github.jhipster</groupId>
                 <artifactId>jhipster-dependencies</artifactId>
                 <version>${jhipster-dependencies.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-gcp-dependencies</artifactId>
-                <version>1.2.2.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -1096,8 +1090,9 @@
                     <artifactId>spring-boot-starter-undertow</artifactId>
                 </dependency>
                 <dependency>
-                    <groupId>org.springframework.cloud</groupId>
-                    <artifactId>spring-cloud-gcp-starter-sql-mysql</artifactId>
+                    <groupId>com.google.cloud.sql</groupId>
+                    <artifactId>mysql-socket-factory</artifactId>
+                    <version>${mysql-socket-factory.version}</version>
                 </dependency>
             </dependencies>
             <build>

--- a/src/main/java/io/github/jhipster/online/service/JHipsterService.java
+++ b/src/main/java/io/github/jhipster/online/service/JHipsterService.java
@@ -25,10 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/resources/config/application-gcp.yml
+++ b/src/main/resources/config/application-gcp.yml
@@ -14,20 +14,10 @@
 # ===================================================================
 
 spring:
-  cloud:
-    gcp:
-      sql:
-        enabled: true
-        database-name: ${DATABASE_NAME}
-        instance-connection-name: ${INSTANCE_CONNECTION_NAME}
   datasource:
-    hikari:
-      data-source-properties:
-        socketFactory: com.google.cloud.sql.mysql.SocketFactory
-        cloudSqlInstance: ${GCP_PROJECT_ID}:${GCP_REGION}:${SQL_INSTANCE_ID}
-      jdbcUrl: jdbc:mysql://google/${DATABASE_NAME}
-      username: ${DATABASE_USERNAME}
-      password: ${DATABASE_PASSWORD}
+    url: jdbc:mysql://google/${DATABASE_NAME}?cloudSqlInstance=${GCP_PROJECT_ID}:${GCP_REGION}:${SQL_INSTANCE_ID}&socketFactory=com.google.cloud.sql.mysql.SocketFactory&useSSL=false
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
   mail:
     host: ${MAIL_HOST}
     port: ${MAIL_PORT}


### PR DESCRIPTION
This changes the database connection without using the Spring GCP dependencies. The Spring GCP dependency is unnecessary and was introduced when we were testing Cloud Run. The database connection can be simplified as in this PR. 

Related to https://github.com/jhipster/jhipster-online/issues/230