### PR TITLE
Fix git config update

### DIFF
--- a/src/main/webapp/app/home/ci-cd/ci-cd.component.ts
+++ b/src/main/webapp/app/home/ci-cd/ci-cd.component.ts
@@ -57,6 +57,7 @@ export class CiCdComponent implements OnInit {
     }
 
     this.gitConfigurationService.sharedData.subscribe((gitConfig: GitConfigurationModel) => {
+      this.gitConfig = gitConfig;
       this.gitlabConfigured = gitConfig.gitlabConfigured || false;
       this.githubConfigured = gitConfig.githubConfigured || false;
     });

--- a/src/main/webapp/app/home/git/git.component.ts
+++ b/src/main/webapp/app/home/git/git.component.ts
@@ -39,6 +39,7 @@ export class GitComponent implements OnInit {
     this.gitlabConfigured = this.gitConfig.gitlabConfigured || false;
     this.githubConfigured = this.gitConfig.githubConfigured || false;
     this.gitConfigurationService.sharedData.subscribe((gitConfig: GitConfigurationModel) => {
+      this.gitConfig = gitConfig;
       this.gitlabConfigured = gitConfig.gitlabConfigured || false;
       this.githubConfigured = gitConfig.githubConfigured || false;
     });

--- a/src/main/webapp/app/home/jdl-metadata/jdl-studio.component.ts
+++ b/src/main/webapp/app/home/jdl-metadata/jdl-studio.component.ts
@@ -111,6 +111,7 @@ export class ApplyJdlStudioComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.gitConfigurationService.sharedData.subscribe((gitConfig: GitConfigurationModel) => {
+      this.gitConfig = gitConfig;
       this.gitlabConfigured = gitConfig.gitlabConfigured || false;
       this.githubConfigured = gitConfig.githubConfigured || false;
     });

--- a/src/main/webapp/app/shared/git-provider/git-provider.component.ts
+++ b/src/main/webapp/app/shared/git-provider/git-provider.component.ts
@@ -51,10 +51,13 @@ export class JhiGitProviderAlertComponent implements OnInit {
       this.gitConfig = gitConfig;
       this.gitlabConfigured = gitConfig.gitlabConfigured;
       this.githubConfigured = gitConfig.githubConfigured;
+      this.updateGitProviderName();
     });
     this.updateGitProviderName();
     this.noGitProvidersMessage = `There is no Git provider available, please contact your administrator to configure one.`;
+  }
 
+  updateMessages(): void {
     if (this.tab === 'ci-cd') {
       this.warningMessage = ` To configure Continuous Integration/Continuous Deployment on your ${this.displayedGitProvider} project,
                 you must authorize JHipster Online to access your ${this.displayedGitProvider} account.`;
@@ -94,6 +97,7 @@ export class JhiGitProviderAlertComponent implements OnInit {
     } else if (!this.gitConfig.githubAvailable && this.gitConfig.gitlabAvailable) {
       this.displayedGitProvider = 'GitLab';
     }
+    this.updateMessages();
   }
 }
 


### PR DESCRIPTION
fixes opening a page directly and logging in without remember-me

Similar to https://github.com/jhipster/jhipster-online/issues/76

## Instructions to Reproduce
- Log Out
- Open one of the following pages in a new tab/window and login WITHOUT remember-me:
  - https://start.jhipster.tech/git
  - https://start.jhipster.tech/ci-cd

The page will look different than if you were authenticated and navigate to the page.

CI Page - [Broken](https://user-images.githubusercontent.com/4294623/94944128-cb7d4980-04a6-11eb-9787-a1eb6e965fff.png) - [Working](https://user-images.githubusercontent.com/4294623/94944122-cae4b300-04a6-11eb-9d63-255c50583498.png)
Git Page - [Broken](https://user-images.githubusercontent.com/4294623/94944129-cc15e000-04a6-11eb-824b-5637bd3bfd30.png) - [Working](https://user-images.githubusercontent.com/4294623/94944111-c7512c00-04a6-11eb-8dc5-269a19689ed0.png)