### PR TITLE
Print Exceptions via Logger Instead of Using printStackTrace

### DIFF
--- a/src/main/java/io/github/jhipster/online/service/CiCdService.java
+++ b/src/main/java/io/github/jhipster/online/service/CiCdService.java
@@ -134,7 +134,7 @@ public class CiCdService {
             this.logsService.addLog(ciCdId, "Generation finished");
         } catch (Exception e) {
             this.logsService.addLog(ciCdId, "Error during generation: " + e.getMessage());
-            log.error(e.getMessage(), e);
+            log.error("Generation failed", e);
             this.logsService.addLog(ciCdId, "Generation failed");
         }
     }

--- a/src/main/java/io/github/jhipster/online/service/CiCdService.java
+++ b/src/main/java/io/github/jhipster/online/service/CiCdService.java
@@ -134,7 +134,7 @@ public class CiCdService {
             this.logsService.addLog(ciCdId, "Generation finished");
         } catch (Exception e) {
             this.logsService.addLog(ciCdId, "Error during generation: " + e.getMessage());
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             this.logsService.addLog(ciCdId, "Generation failed");
         }
     }

--- a/src/main/java/io/github/jhipster/online/service/JdlService.java
+++ b/src/main/java/io/github/jhipster/online/service/JdlService.java
@@ -152,7 +152,7 @@ public class JdlService {
             this.logsService.addLog(applyJdlId, "Generation finished");
         } catch (Exception e) {
             this.logsService.addLog(applyJdlId, "Error during generation: " + e.getMessage());
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             this.logsService.addLog(applyJdlId, "Generation failed");
         }
     }

--- a/src/main/java/io/github/jhipster/online/service/JdlService.java
+++ b/src/main/java/io/github/jhipster/online/service/JdlService.java
@@ -152,7 +152,7 @@ public class JdlService {
             this.logsService.addLog(applyJdlId, "Generation finished");
         } catch (Exception e) {
             this.logsService.addLog(applyJdlId, "Error during generation: " + e.getMessage());
-            log.error(e.getMessage(), e);
+            log.error("Generation failed", e);
             this.logsService.addLog(applyJdlId, "Generation failed");
         }
     }

--- a/src/main/java/io/github/jhipster/online/service/YoRCService.java
+++ b/src/main/java/io/github/jhipster/online/service/YoRCService.java
@@ -143,7 +143,7 @@ public class YoRCService {
 
             log.debug("Parsed json:\n{}", yorc);
         } catch (IOException e) {
-            log.error(e.getMessage(), e);
+            log.error("Generation failed", e);
         }
     }
 

--- a/src/main/java/io/github/jhipster/online/service/YoRCService.java
+++ b/src/main/java/io/github/jhipster/online/service/YoRCService.java
@@ -143,7 +143,7 @@ public class YoRCService {
 
             log.debug("Parsed json:\n{}", yorc);
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Hey folks,

just changed a few lines where exceptions where printed by the `printStackTrace`-method and not by the provided logger.
Thought that this would be an improvement to issue #209.

