### PR TITLE
Change the generated projects default branch name to main

### DIFF
--- a/src/main/java/io/github/jhipster/online/service/GitService.java
+++ b/src/main/java/io/github/jhipster/online/service/GitService.java
@@ -49,7 +49,7 @@ public class GitService {
     }
 
     public void pushNewApplicationToGit(User user, File workingDir, String organization, String applicationName, GitProvider gitProvider)
-        throws GitAPIException, URISyntaxException {
+        throws GitAPIException, URISyntaxException, IOException {
         log.info("Create Git repository for {}", workingDir);
         Git git = Git.init().setDirectory(workingDir).call();
 
@@ -70,6 +70,10 @@ public class GitService {
         remoteAddCommand.setUri(urIish);
         remoteAddCommand.call();
 
+        String currentBranch = git.getRepository().getFullBranch();
+        if (currentBranch.equals("refs/heads/master")) {
+            git.branchRename().setNewName("main").call();
+        }
         this.push(git, workingDir, user, organization, applicationName, gitProvider);
 
         log.debug("Repository successfully pushed!");


### PR DESCRIPTION
This renames the default branch of the generated project to main

Resolves https://github.com/jhipster/jhipster-online/issues/258