### PR TITLE
Clear old tokens after successful login

### DIFF
--- a/src/main/webapp/app/core/auth/auth-jwt.service.ts
+++ b/src/main/webapp/app/core/auth/auth-jwt.service.ts
@@ -55,8 +55,10 @@ export class AuthServerProvider {
     const jwt = response.id_token;
     if (rememberMe) {
       this.$localStorage.store('authenticationToken', jwt);
+      this.$sessionStorage.clear('authenticationToken');
     } else {
       this.$sessionStorage.store('authenticationToken', jwt);
+      this.$localStorage.clear('authenticationToken');
     }
   }
 }


### PR DESCRIPTION
apply fix from https://github.com/jhipster/generator-jhipster/pull/12610

possibly related to https://github.com/jhipster/jhipster-online/issues/262 (after authentication success, a second 401 was received, guessing it used the old token)

Steps to reproduce issue:
- Login with remember-me
- Make JWT token invalid by adding random letters to localStorage's `jhi-authenticationtoken` value (in browser dev tools)
  - If the token expired from time, the same issue would happen
- Login without remember-me
- Authentication fails - it uses the invalid localStorage token over the sessionStorage token