### PR TITLE
Use Default Branch when creating PRs

### DIFF
--- a/src/main/java/io/github/jhipster/online/service/GithubService.java
+++ b/src/main/java/io/github/jhipster/online/service/GithubService.java
@@ -32,10 +32,7 @@ import java.net.ConnectException;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
-import org.kohsuke.github.GHCreateRepositoryBuilder;
-import org.kohsuke.github.GHMyself;
-import org.kohsuke.github.GHOrganization;
-import org.kohsuke.github.GitHub;
+import org.kohsuke.github.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
@@ -204,10 +201,8 @@ public class GithubService implements GitProviderService {
         log.info("Creating Pull Request on repository {} / {}", organization, repositoryName);
 
         GitHub gitHub = this.getConnection(user);
-        int number = gitHub
-            .getRepository(organization + "/" + repositoryName)
-            .createPullRequest(title, branchName, "main", body)
-            .getNumber();
+        GHRepository repository = gitHub.getRepository(organization + "/" + repositoryName);
+        int number = repository.createPullRequest(title, branchName, repository.getDefaultBranch(), body).getNumber();
 
         log.info("Pull Request created!");
         return number;

--- a/src/main/java/io/github/jhipster/online/service/GitlabService.java
+++ b/src/main/java/io/github/jhipster/online/service/GitlabService.java
@@ -264,8 +264,9 @@ public class GitlabService implements GitProviderService {
         throws IOException {
         log.info("Creating Merge Request on repository {} / {}", group, repositoryName);
         GitlabAPI gitlab = getConnection(user);
-        int number = gitlab.getProject(group, repositoryName).getId();
-        GitlabMergeRequest mergeRequest = gitlab.createMergeRequest(number, branchName, "main", null, title);
+        GitlabProject gitlabProject = gitlab.getProject(group, repositoryName);
+        int projectId = gitlabProject.getId();
+        GitlabMergeRequest mergeRequest = gitlab.createMergeRequest(projectId, branchName, gitlabProject.getDefaultBranch(), null, title);
         log.info("Merge Request created!");
         return mergeRequest.getIid();
     }


### PR DESCRIPTION
As per the following comment by @ruddell; 

https://github.com/jhipster/jhipster-online/issues/258#issuecomment-725646522

this pull request adds support for backward compatibility of existing repos with `master` branch. Otherwise it seems that when trying to create pull requests it will give an error due to not having the `main` branch. 