### PR TITLE
Add force-insights back to jhipster-online

### DIFF
--- a/src/main/java/io/github/jhipster/online/service/JHipsterService.java
+++ b/src/main/java/io/github/jhipster/online/service/JHipsterService.java
@@ -36,6 +36,8 @@ public class JHipsterService {
 
     public final Logger log = LoggerFactory.getLogger(JHipsterService.class);
 
+    private static final String FORCE_INSIGHT = "--force-insight";
+
     private static final String SKIP_CHECKS = "--skip-checks";
 
     private static final String SKIP_INSTALL = "--skip-install";
@@ -65,12 +67,22 @@ public class JHipsterService {
 
     public void generateApplication(String generationId, File workingDir) throws IOException {
         this.logsService.addLog(generationId, "Running JHipster");
-        this.runProcess(generationId, workingDir, jhipsterCommand, SKIP_CHECKS, SKIP_INSTALL, "--skip-cache", "--skip-git");
+        this.runProcess(generationId, workingDir, jhipsterCommand, FORCE_INSIGHT, SKIP_CHECKS, SKIP_INSTALL, "--skip-cache", "--skip-git");
     }
 
     public void runImportJdl(String generationId, File workingDir, String jdlFileName) throws IOException {
         this.logsService.addLog(generationId, "Running `jhipster import-jdl`");
-        this.runProcess(generationId, workingDir, jhipsterCommand, "import-jdl", jdlFileName + ".jh", SKIP_CHECKS, SKIP_INSTALL, "--force");
+        this.runProcess(
+                generationId,
+                workingDir,
+                jhipsterCommand,
+                "import-jdl",
+                jdlFileName + ".jh",
+                FORCE_INSIGHT,
+                SKIP_CHECKS,
+                SKIP_INSTALL,
+                "--force"
+            );
     }
 
     public void addCiCd(String generationId, File workingDir, CiCdTool ciCdTool) throws IOException {
@@ -85,6 +97,7 @@ public class JHipsterService {
                 jhipsterCommand,
                 "ci-cd",
                 "--autoconfigure-" + ciCdTool.command(),
+                FORCE_INSIGHT,
                 SKIP_CHECKS,
                 SKIP_INSTALL,
                 "--force"

--- a/src/test/java/io/github/jhipster/online/service/JHipsterServiceTest.java
+++ b/src/test/java/io/github/jhipster/online/service/JHipsterServiceTest.java
@@ -101,6 +101,7 @@ class JHipsterServiceTest {
                 generationId,
                 tempDir.toFile(),
                 applicationProperties.getJhipsterCmd().getCmd(),
+                "--force-insight",
                 "--skip" + "-checks",
                 "--skip-install",
                 "--skip-cache",
@@ -115,6 +116,7 @@ class JHipsterServiceTest {
                 generationId,
                 tempDir.toFile(),
                 applicationProperties.getJhipsterCmd().getCmd(),
+                "--force-insight",
                 "--skip" + "-checks",
                 "--skip-install",
                 "--skip-cache",
@@ -134,6 +136,7 @@ class JHipsterServiceTest {
                 applicationProperties.getJhipsterCmd().getCmd(),
                 "import-jdl",
                 jdlFileName + ".jh",
+                "--force-insight",
                 "--skip-checks",
                 "--skip-install",
                 "--force"
@@ -149,6 +152,7 @@ class JHipsterServiceTest {
                 applicationProperties.getJhipsterCmd().getCmd(),
                 "import-jdl",
                 jdlFileName + ".jh",
+                "--force-insight",
                 "--skip-checks",
                 "--skip-install",
                 "--force"
@@ -167,6 +171,7 @@ class JHipsterServiceTest {
                 applicationProperties.getJhipsterCmd().getCmd(),
                 "ci-cd",
                 "--autoconfigure-" + ciCdTool.command(),
+                "--force-insight",
                 "--skip-checks",
                 "--skip-install",
                 "--force"
@@ -182,6 +187,7 @@ class JHipsterServiceTest {
                 applicationProperties.getJhipsterCmd().getCmd(),
                 "ci-cd",
                 "--autoconfigure-" + ciCdTool.command(),
+                "--force-insight",
                 "--skip-checks",
                 "--skip-install",
                 "--force"


### PR DESCRIPTION
The `force-insights` option needs to be supported and I believe there's a regression in the generator regarding this. Ideally we should fix this in the generator. I've opened a PR there. 

Related https://github.com/jhipster/jhipster-online/pull/288

Related https://github.com/jhipster/generator-jhipster/pull/14485