### PR TITLE
Switch docker base image to jhipster image.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+#
+# Copyright 2013-2021 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    # Publish semver tags as releases.
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.3.4
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3.5.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,19 @@
-FROM adoptopenjdk:11-jdk-hotspot-bionic as builder
-ADD . /code/
+FROM ghcr.io/jhipster/generator-jhipster:v7.2.0-0
+USER jhipster
+COPY --chown=jhipster:jhipster . /home/jhipster/jhipster-online/
 RUN \
-    apt-get update && \
-    apt-get install build-essential -y && \
-    cd /code/ && \
+    cd /home/jhipster/jhipster-online/ && \
     rm -Rf target node_modules && \
-    chmod +x /code/mvnw && \
+    chmod +x mvnw && \
     sleep 1 && \
     ./mvnw package -Pgcp -DskipTests && \
-    mv /code/target/*.war / && \
-    apt-get clean && \
-    rm -Rf /code/ /root/.m2 /root/.cache /tmp/* /var/lib/apt/lists/* /var/tmp/*  && \
-    mkdir /tmp/jhispter && mkdir /tmp/jhispter/applications
+    mv /home/jhipster/jhipster-online/target/*.war /home/jhipster && \
+    rm -Rf /home/jhipster/jhipster-online/ /home/jhipster/.m2 /home/jhipster/.cache /tmp/* /var/tmp/* 
 
-FROM adoptopenjdk:11-jre-hotspot
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     JHIPSTER_SLEEP=0 \
     JAVA_OPTS=""
-RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - && \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && \
-    apt-get install -y nodejs yarn && \
-    yarn global add generator-jhipster@7.2.0
 CMD echo "The application will start in ${JHIPSTER_SLEEP}s..." && \
     sleep ${JHIPSTER_SLEEP} && \
-    java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /jhonline*.war
+    java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /home/jhipster/jhonline*.war
 EXPOSE 8080
-COPY --from=builder /*.war .


### PR DESCRIPTION
Reuse JHipster docker image.
It has everything required to run jhipster already.