### PR TITLE
fix statistics creation when creationTime is provided

### DIFF
--- a/src/main/java/io/github/jhipster/online/domain/deserializer/YoRCDeserializer.java
+++ b/src/main/java/io/github/jhipster/online/domain/deserializer/YoRCDeserializer.java
@@ -64,7 +64,8 @@ public class YoRCDeserializer extends StdDeserializer<YoRC> {
         String applicationType = getDefaultIfNull(node.get("applicationType"), "");
         boolean enableTranslation = getDefaultIfNull(node.get("enableTranslation"), false);
         String nativeLanguage = getDefaultIfNull(node.get("nativeLanguage"), "");
-        String creationDate = getDefaultIfNull(node.get("creationTimestamp"), Instant.now().toString());
+        Instant creationDate = getCreationDate(node.get("creationTimestamp"));
+
         boolean hasProtractor = false;
         boolean hasGatling = false;
         boolean hasCucumber = false;
@@ -114,7 +115,15 @@ public class YoRCDeserializer extends StdDeserializer<YoRC> {
             .hasGatling(hasGatling)
             .hasCucumber(hasCucumber)
             .selectedLanguages(languages)
-            .creationDate(Instant.parse(creationDate));
+            .creationDate(creationDate);
+    }
+
+    private Instant getCreationDate(JsonNode node) {
+        if (node == null) {
+            return Instant.now();
+        }
+
+        return Instant.ofEpochMilli(node.asLong());
     }
 
     private String getDefaultIfNull(JsonNode node, String defaultValue) {

--- a/src/main/java/io/github/jhipster/online/domain/deserializer/YoRCDeserializer.java
+++ b/src/main/java/io/github/jhipster/online/domain/deserializer/YoRCDeserializer.java
@@ -25,14 +25,9 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.github.jhipster.online.domain.YoRC;
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.TimeZone;
 
 public class YoRCDeserializer extends StdDeserializer<YoRC> {
 

--- a/src/test/java/io/github/jhipster/online/web/rest/StatisticsResourceIntTest.java
+++ b/src/test/java/io/github/jhipster/online/web/rest/StatisticsResourceIntTest.java
@@ -79,7 +79,7 @@ class StatisticsResourceIntTest {
     @Autowired
     private ExceptionTranslator exceptionTranslator;
 
-    private MockMvc restStatiticsMockMvc;
+    private MockMvc restStatisticsMockMvc;
 
     private YoRC yoRC;
 
@@ -185,7 +185,7 @@ class StatisticsResourceIntTest {
             entityStatService
         );
 
-        this.restStatiticsMockMvc =
+        this.restStatisticsMockMvc =
             MockMvcBuilders
                 .standaloneSetup(statisticsResource)
                 .setMessageConverters(httpMessageConverters)
@@ -196,13 +196,13 @@ class StatisticsResourceIntTest {
     @Test
     @Transactional
     void shouldNotGetCountWithUnknownFrequency() throws Exception {
-        restStatiticsMockMvc.perform(get("/api/s/count-yo/{frequency}", "every minutes")).andExpect(status().isBadRequest());
+        restStatisticsMockMvc.perform(get("/api/s/count-yo/{frequency}", "every minutes")).andExpect(status().isBadRequest());
     }
 
     @Test
     @Transactional
     void shouldNotGetFieldCountWithUnknownFieldOrFrequency() throws Exception {
-        restStatiticsMockMvc
+        restStatisticsMockMvc
             .perform(get("/api/s/yo/{field}/{frequency}", "clientFramework", "every minutes"))
             .andExpect(status().isBadRequest());
     }
@@ -212,7 +212,7 @@ class StatisticsResourceIntTest {
     void getYoCount() throws Exception {
         int databaseSizeBeforeAdd = yoRCRepository.findAll().size();
 
-        restStatiticsMockMvc.perform(get("/api/s/count-yo")).andExpect(status().isOk());
+        restStatisticsMockMvc.perform(get("/api/s/count-yo")).andExpect(status().isOk());
 
         YoRC yorc = new YoRC().owner(new GeneratorIdentity());
         generatorIdentityRepository.saveAndFlush(yorc.getOwner());
@@ -230,7 +230,7 @@ class StatisticsResourceIntTest {
 
         final String content = dummyYo(generatorJhipsterWithoutCreationTimestamp);
 
-        restStatiticsMockMvc.perform(post("/api/s/entry").content(content)).andExpect(status().isCreated());
+        restStatisticsMockMvc.perform(post("/api/s/entry").content(content)).andExpect(status().isCreated());
 
         int databaseSizeAfterAdd = yoRCRepository.findAll().size();
 
@@ -244,7 +244,7 @@ class StatisticsResourceIntTest {
 
         final String content = dummyYo(generatorJhipsterWithCreationTimestamp);
 
-        restStatiticsMockMvc.perform(post("/api/s/entry").content(content)).andExpect(status().isCreated());
+        restStatisticsMockMvc.perform(post("/api/s/entry").content(content)).andExpect(status().isCreated());
 
         int databaseSizeAfterAdd = yoRCRepository.findAll().size();
 

--- a/src/test/java/io/github/jhipster/online/web/rest/StatisticsResourceIntTest.java
+++ b/src/test/java/io/github/jhipster/online/web/rest/StatisticsResourceIntTest.java
@@ -81,8 +81,6 @@ class StatisticsResourceIntTest {
 
     private MockMvc restStatisticsMockMvc;
 
-    private YoRC yoRC;
-
     private String generatorId = "cf51ff78-187a-4554-9b09-8f6f95f1a7a5";
 
     private final String generatorJhipsterWithCreationTimestamp =

--- a/src/test/java/io/github/jhipster/online/web/rest/StatisticsResourceIntTest.java
+++ b/src/test/java/io/github/jhipster/online/web/rest/StatisticsResourceIntTest.java
@@ -85,9 +85,41 @@ class StatisticsResourceIntTest {
 
     private String generatorId = "cf51ff78-187a-4554-9b09-8f6f95f1a7a5";
 
-    private String dummyYo =
+    private final String generatorJhipsterWithCreationTimestamp =
         "{\n" +
-        "        \"generator-jhipster\": {\n" +
+        "        \"useYarn\": false,\n" +
+        "            \"experimental\": false,\n" +
+        "            \"skipI18nQuestion\": true,\n" +
+        "            \"logo\": false,\n" +
+        "            \"clientPackageManager\": \"npm\",\n" +
+        "            \"creationTimestamp\": 1650832223564,\n" +
+        "            \"cacheProvider\": \"ehcache\",\n" +
+        "            \"enableHibernateCache\": true,\n" +
+        "            \"websocket\": false,\n" +
+        "            \"databaseType\": \"sql\",\n" +
+        "            \"devDatabaseType\": \"h2Disk\",\n" +
+        "            \"prodDatabaseType\": \"mysql\",\n" +
+        "            \"searchEngine\": false,\n" +
+        "            \"messageBroker\": false,\n" +
+        "            \"serviceDiscoveryType\": false,\n" +
+        "            \"buildTool\": \"maven\",\n" +
+        "            \"enableSwaggerCodegen\": false,\n" +
+        "            \"authenticationType\": \"jwt\",\n" +
+        "            \"serverPort\": \"8080\",\n" +
+        "            \"clientFramework\": \"angularX\",\n" +
+        "            \"withAdminUi\": \"true\",\n" +
+        "            \"useSass\": false,\n" +
+        "            \"testFrameworks\": [],\n" +
+        "        \"enableTranslation\": true,\n" +
+        "            \"nativeLanguage\": \"en\",\n" +
+        "            \"languages\": [\n" +
+        "        \"en\"\n" +
+        "      ],\n" +
+        "        \"applicationType\": \"monolith\"\n" +
+        "    },\n";
+
+    private final String generatorJhipsterWithoutCreationTimestamp =
+        "{\n" +
         "        \"useYarn\": false,\n" +
         "            \"experimental\": false,\n" +
         "            \"skipI18nQuestion\": true,\n" +
@@ -116,21 +148,29 @@ class StatisticsResourceIntTest {
         "        \"en\"\n" +
         "      ],\n" +
         "        \"applicationType\": \"monolith\"\n" +
-        "    },\n" +
-        "        \"generator-id\": \"" +
-        generatorId +
-        "\",\n" +
-        "        \"generator-version\": \"5.1.0\",\n" +
-        "        \"git-provider\": \"local\",\n" +
-        "        \"node-version\": \"v8.11.1\",\n" +
-        "        \"os\": \"linux:4.15.0-29-generic\",\n" +
-        "        \"arch\": \"x64\",\n" +
-        "        \"cpu\": \"Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz\",\n" +
-        "        \"cores\": 8,\n" +
-        "        \"memory\": 16776642560,\n" +
-        "        \"user-language\": \"en_GB\",\n" +
-        "        \"isARegeneration\": true\n" +
-        "    }";
+        "    },\n";
+
+    private String dummyYo(String dummyGeneratorJhipsterData) {
+        return (
+            "{\n" +
+            "        \"generator-jhipster\":" +
+            dummyGeneratorJhipsterData +
+            "        \"generator-id\": \"" +
+            generatorId +
+            "\",\n" +
+            "        \"generator-version\": \"5.1.0\",\n" +
+            "        \"git-provider\": \"local\",\n" +
+            "        \"node-version\": \"v8.11.1\",\n" +
+            "        \"os\": \"linux:4.15.0-29-generic\",\n" +
+            "        \"arch\": \"x64\",\n" +
+            "        \"cpu\": \"Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz\",\n" +
+            "        \"cores\": 8,\n" +
+            "        \"memory\": 16776642560,\n" +
+            "        \"user-language\": \"en_GB\",\n" +
+            "        \"isARegeneration\": true\n" +
+            "    }"
+        );
+    }
 
     @BeforeEach
     public void setup() {
@@ -188,7 +228,23 @@ class StatisticsResourceIntTest {
     void addEntry() throws Exception {
         int databaseSizeBeforeAdd = yoRCRepository.findAll().size();
 
-        restStatiticsMockMvc.perform(post("/api/s/entry").content(dummyYo)).andExpect(status().isCreated());
+        final String content = dummyYo(generatorJhipsterWithoutCreationTimestamp);
+
+        restStatiticsMockMvc.perform(post("/api/s/entry").content(content)).andExpect(status().isCreated());
+
+        int databaseSizeAfterAdd = yoRCRepository.findAll().size();
+
+        assertThat(databaseSizeAfterAdd).isEqualTo(databaseSizeBeforeAdd + 1);
+    }
+
+    @Test
+    @Transactional
+    void addEntryWithCreationTimestamp() throws Exception {
+        int databaseSizeBeforeAdd = yoRCRepository.findAll().size();
+
+        final String content = dummyYo(generatorJhipsterWithCreationTimestamp);
+
+        restStatiticsMockMvc.perform(post("/api/s/entry").content(content)).andExpect(status().isCreated());
 
         int databaseSizeAfterAdd = yoRCRepository.findAll().size();
 

--- a/src/test/java/io/github/jhipster/online/web/rest/StatisticsResourceIntTest.java
+++ b/src/test/java/io/github/jhipster/online/web/rest/StatisticsResourceIntTest.java
@@ -81,7 +81,7 @@ class StatisticsResourceIntTest {
 
     private MockMvc restStatisticsMockMvc;
 
-    private String generatorId = "cf51ff78-187a-4554-9b09-8f6f95f1a7a5";
+    private final String generatorId = "cf51ff78-187a-4554-9b09-8f6f95f1a7a5";
 
     private final String generatorJhipsterWithCreationTimestamp =
         "{\n" +


### PR DESCRIPTION
This fixes the bug where the request to save yorc statistics fails when
a `creationTime` was provided in the `generator-jhipster` part of the
entry payload. The issue is that `Instant.parse()` was called with a
timestamp while it only accepts an ISO formatted instant.

Fix jhipster/generator-jhipster#18238