### PR TITLE
Update GitHub Action to deploy to GCP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
 
       # Setup gcloud CLI
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@main
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: '418.0.0'
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,8 +54,14 @@ jobs:
           env_variables.GITLAB_CLIENT_SECRET: ${{ secrets.GITLAB_CLIENT_SECRET }}
           env_variables.GITLAB_REDIRECT_URI: ${{ secrets.GITLAB_REDIRECT_URI }}
 
-      # Setup gcloud CLI
-      - name: Set up Cloud SDK
+      # Setup Google Cloud
+      - id: Authenticate to Google Cloud
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
         with:
           version: '418.0.0'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jhonline",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "JHipster Online is the best place to generate JHipster applications, with no installation required!",
   "license": "Apache-2.0",
   "keywords": [

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.jhipster.online</groupId>
     <artifactId>jhonline</artifactId>
-    <version>2.18.0</version>
+    <version>2.18.1</version>
     <packaging>war</packaging>
     <name>Jhonline</name>
 


### PR DESCRIPTION
The google-github-actions/setup-gcloud was updated and can't be used anymore to authenticate 