### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ files, using the standard `spring.datasource` keys.
 JHipster Online uses JWT to secure the application. For a production application, it is therefore **mandatory** that:
 
 - The `jhipster.security.authentication.jwt.key` is configured, and that key is stored securely (**not** commited in your application's Git repository).
-  We recommend to configure it as an environnement variable on your server, or in a specific Spring Boot `application.yml` file that is stored
+  We recommend to configure it as an environment variable on your server, or in a specific Spring Boot `application.yml` file that is stored
   in your application's folder on your production server (which is our configuration on the official [JHipster Online website](https://start.jhipster.tech/)).
 - The application is only available through HTTPS. You can configure it using Spring Boot (please read the comments in the `application-prod.yml` file), or
   using an Apache 2 HTTP server with Let's Encrypt on front of your application (which is our configuration on the official [JHipster Online website](https://start.jhipster.tech/)).


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "environnement" to "environment" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.