### PR TITLE
Fix testcontainers + MySQL bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.17.3</version>
+                <version>1.20.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -18,8 +18,8 @@ spring:
     name: jhonline
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
-    url: jdbc:tc:mysql:8://localhost:3306/jhipster-online?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
-    username: root
+    url: jdbc:tc:mysql:8.2.0:///jhipster-online?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
+    username: test
     password:
     hikari:
       poolName: Hikari


### PR DESCRIPTION
CI/CD has been failing for some time because we use "mysql:8" without specifying the minor/patch versions, and there has been a bug introduced since MySQL 8.3.0.

See https://github.com/testcontainers/testcontainers-java/issues/8130