### PR TITLE
Prepare 2.41.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jhonline",
-  "version": "2.41.0",
+  "version": "2.41.1",
   "description": "JHipster Online is the best place to generate JHipster applications, with no installation required!",
   "license": "Apache-2.0",
   "keywords": [

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.jhipster.online</groupId>
     <artifactId>jhonline</artifactId>
-    <version>2.41.0</version>
+    <version>2.41.1</version>
     <packaging>war</packaging>
     <name>Jhonline</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -702,8 +702,8 @@
                                 <version>[${maven.version},)</version>
                             </requireMavenVersion>
                             <requireJavaVersion>
-                                <message>You are running an incompatible version of Java. JHipster supports JDK 8 to 13.</message>
-                                <version>[1.8,21)</version>
+                                <message>You are running an incompatible version of Java. JHipster Online requires JDK 17 or newer.</message>
+                                <version>[17,)</version>
                             </requireJavaVersion>
                         </rules>
                     </configuration>


### PR DESCRIPTION
Bump jhipster-online to 2.41.1 and update the Java version check so the JHipster 9.1.0 Docker image can build and deploy successfully.