### PR TITLE
escape user input reflected in HTTP response bodies

### DIFF
--- a/src/main/java/io/github/jhipster/online/util/SanitizeInputs.java
+++ b/src/main/java/io/github/jhipster/online/util/SanitizeInputs.java
@@ -20,6 +20,7 @@
 package io.github.jhipster.online.util;
 
 import java.util.regex.Pattern;
+import org.springframework.web.util.HtmlUtils;
 
 public class SanitizeInputs {
 
@@ -44,5 +45,13 @@ public class SanitizeInputs {
     public static boolean isLettersNumbersAndSpaces(String inputString) {
         if (inputString == null) return false;
         return ALPHANUMERIC_AND_SPACES_REGEX.matcher(inputString).matches();
+    }
+
+    /**
+     * Escapes HTML markup, so that a user controlled value can safely be echoed back in an HTTP response body.
+     */
+    public static String escapeHtml(String inputString) {
+        if (inputString == null) return null;
+        return HtmlUtils.htmlEscape(inputString);
     }
 }

--- a/src/main/java/io/github/jhipster/online/web/rest/AccountResource.java
+++ b/src/main/java/io/github/jhipster/online/web/rest/AccountResource.java
@@ -111,7 +111,7 @@ public class AccountResource {
     @GetMapping("/authenticate")
     public String isAuthenticated(HttpServletRequest request) {
         log.debug("REST request to check if the current user is authenticated");
-        return request.getRemoteUser();
+        return SanitizeInputs.escapeHtml(request.getRemoteUser());
     }
 
     /**

--- a/src/main/java/io/github/jhipster/online/web/rest/GitResource.java
+++ b/src/main/java/io/github/jhipster/online/web/rest/GitResource.java
@@ -136,7 +136,7 @@ public class GitResource {
                     params.put("redirect_uri", applicationProperties.getGitlab().getRedirectUri());
                     break;
                 default:
-                    return new ResponseEntity<>(UNKNOWN_GIT_PROVIDER + gitProvider, HttpStatus.INTERNAL_SERVER_ERROR);
+                    return unknownGitProvider(gitProvider);
             }
 
             ObjectMapper objectMapper = new ObjectMapper();
@@ -287,7 +287,7 @@ public class GitResource {
                     this.gitlabService.syncUserFromGitProvider();
                     break;
                 default:
-                    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(UNKNOWN_GIT_PROVIDER + gitProvider);
+                    return unknownGitProvider(gitProvider);
             }
             return ResponseEntity.ok().build();
         } catch (Exception e) {
@@ -299,9 +299,17 @@ public class GitResource {
                     log.error("Could not refresh GitLab data for User `{}`: {}", SecurityUtils.getCurrentUserLogin(), e);
                     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("GitLab data could not be " + "refreshed");
                 default:
-                    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(UNKNOWN_GIT_PROVIDER + gitProvider);
+                    return unknownGitProvider(gitProvider);
             }
         }
+    }
+
+    /**
+     * Builds the error response for an unsupported git provider, escaping the user supplied value so that it cannot be
+     * used to inject markup into the response body.
+     */
+    private static ResponseEntity<String> unknownGitProvider(String gitProvider) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(UNKNOWN_GIT_PROVIDER + SanitizeInputs.escapeHtml(gitProvider));
     }
 
     /**

--- a/src/test/java/io/github/jhipster/online/util/SanitizeInputsTest.java
+++ b/src/test/java/io/github/jhipster/online/util/SanitizeInputsTest.java
@@ -55,4 +55,13 @@ class SanitizeInputsTest {
         assertThat(SanitizeInputs.isLettersNumbersAndSpaces("2309/\n482\r$3\t023")).isFalse();
         assertThat(SanitizeInputs.isLettersNumbersAndSpaces("23};09/\n482\r$3\t023**")).isFalse();
     }
+
+    @Test
+    void escapeHtml() {
+        assertThat(SanitizeInputs.escapeHtml(null)).isNull();
+        assertThat(SanitizeInputs.escapeHtml("github")).isEqualTo("github");
+        assertThat(SanitizeInputs.escapeHtml("user@jhipster.tech")).isEqualTo("user@jhipster.tech");
+        assertThat(SanitizeInputs.escapeHtml("<script>alert(1)</script>")).isEqualTo("&lt;script&gt;alert(1)&lt;/script&gt;");
+        assertThat(SanitizeInputs.escapeHtml("\"><img src=x onerror=alert(1)>")).isEqualTo("&quot;&gt;&lt;img src=x onerror=alert(1)&gt;");
+    }
 }


### PR DESCRIPTION
## What

Fixes four reflected cross-site scripting vulnerabilities (CWE-79) where a
request-controlled value was written directly into an HTTP response body.

| Location | Tainted value |
|---|---|
| `GitResource.java:139` | `gitProvider` path variable (`save-token`) |
| `GitResource.java:290` | `gitProvider` path variable (`refresh`) |
| `GitResource.java:302` | `gitProvider` path variable (`refresh`, catch block) |
| `AccountResource.java:114` | `request.getRemoteUser()` (`/api/authenticate`) |

## Why

`StringHttpMessageConverter` supports all media types, so a request carrying
`Accept: text/html` gets the reflected value served back as HTML and the
injected markup executes in the victim's browser.

## How

All four sites share one root cause, so they share one fix. Added `escapeHtml`
to the existing `SanitizeInputs` utility, alongside the `sanitizeInput` /
`isAlphaNumeric` helpers already used across the REST layer:

```java
public static String escapeHtml(String inputString) {
    if (inputString == null) return null;
    return HtmlUtils.htmlEscape(inputString);
}
```

`HtmlUtils` comes from spring-web, already a compile dependency. No new
dependency and no version constraint changes.

The three GitResource sites were the identical `UNKNOWN_GIT_PROVIDER + gitProvider`
expression, so they collapse into a single private `unknownGitProvider(...)` helper
rather than three separately written fixes.

## Behavior impact

None for valid input. `Constants.LOGIN_REGEX` is `^[_.@A-Za-z0-9-]*$`, so escaping
is the identity function for every valid login, and `null` still passes through
for the unauthenticated case.
